### PR TITLE
Improve GitHub API logging and add retry/auth

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y jq
       - name: Update table
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/update_repo_table.sh
       - name: Generate PR summary
         shell: bash

--- a/scripts/update_repo_table.sh
+++ b/scripts/update_repo_table.sh
@@ -4,15 +4,54 @@ set -euo pipefail
 USER="arran4"
 
 TMP_DIR=$(mktemp -d)
+
+fetch_github_api() {
+  local url="$1"
+  local accept_header="$2"
+  local output_file="$3"
+
+  echo "Fetching: $url" >&2
+
+  local curl_opts=(
+    -sSL
+    --retry 3
+    --retry-delay 5
+    -H "Accept: $accept_header"
+    -w "%{http_code}"
+  )
+
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    curl_opts+=(-H "Authorization: Bearer $GITHUB_TOKEN")
+  fi
+
+  local response_file="$TMP_DIR/curl_response"
+  local http_code
+
+  http_code=$(curl "${curl_opts[@]}" -o "$response_file" "$url")
+  local exit_code=$?
+
+  if [ $exit_code -ne 0 ]; then
+    echo "Error fetching $url (curl exit code $exit_code)" >&2
+    return $exit_code
+  fi
+
+  if [ "$http_code" -ne 200 ]; then
+    echo "Error fetching $url: HTTP status $http_code" >&2
+    echo "Response body:" >&2
+    cat "$response_file" >&2
+    return 22 # Return 22 to match curl -f behavior
+  fi
+
+  mv "$response_file" "$output_file"
+}
+
 PAGE=1
 ALL="$TMP_DIR/all.json"
 : > "$ALL"
 
 while true; do
   PAGE_FILE="$TMP_DIR/page_${PAGE}.json"
-  curl -fsSL \
-    -H "Accept: application/vnd.github.mercy-preview+json" \
-    "https://api.github.com/users/${USER}/repos?per_page=100&page=${PAGE}" > "$PAGE_FILE"
+  fetch_github_api "https://api.github.com/users/${USER}/repos?per_page=100&page=${PAGE}" "application/vnd.github.mercy-preview+json" "$PAGE_FILE"
   COUNT=$(jq 'length' "$PAGE_FILE")
   jq -s 'add' "$ALL" "$PAGE_FILE" > "$ALL.tmp"
   mv "$ALL.tmp" "$ALL"
@@ -260,9 +299,7 @@ ALL_STARRED="$TMP_DIR/all_starred.json"
 
 while true; do
   PAGE_FILE="$TMP_DIR/page_starred_${PAGE}.json"
-  curl -fsSL \
-    -H "Accept: application/vnd.github.v3+json" \
-    "https://api.github.com/users/${USER}/starred?per_page=100&page=${PAGE}" > "$PAGE_FILE"
+  fetch_github_api "https://api.github.com/users/${USER}/starred?per_page=100&page=${PAGE}" "application/vnd.github.v3+json" "$PAGE_FILE"
   COUNT=$(jq 'length' "$PAGE_FILE")
   jq -s 'add' "$ALL_STARRED" "$PAGE_FILE" > "$ALL_STARRED.tmp"
   mv "$ALL_STARRED.tmp" "$ALL_STARRED"

--- a/scripts/update_repo_table.sh
+++ b/scripts/update_repo_table.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 USER="arran4"
 
 TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 fetch_github_api() {
   local url="$1"
@@ -27,10 +28,8 @@ fetch_github_api() {
   local response_file="$TMP_DIR/curl_response"
   local http_code
 
-  http_code=$(curl "${curl_opts[@]}" -o "$response_file" "$url")
-  local exit_code=$?
-
-  if [ $exit_code -ne 0 ]; then
+  if ! http_code=$(curl "${curl_opts[@]}" -o "$response_file" "$url"); then
+    local exit_code=$?
     echo "Error fetching $url (curl exit code $exit_code)" >&2
     return $exit_code
   fi
@@ -367,5 +366,3 @@ $0==start{print;for(i=1;i<=length(lines);i++)print lines[i];skip=1;next}
 $0==end{skip=0;print;next}
 !skip{print}
 ' "$STARRED_TABLE" "$STARRED_MD" > "$STARRED_MD.tmp" && mv "$STARRED_MD.tmp" "$STARRED_MD"
-
-rm -rf "$TMP_DIR"


### PR DESCRIPTION
This commit addresses the issue of HTTP 403 errors when fetching from the GitHub API in `scripts/update_repo_table.sh`.

It introduces a `fetch_github_api` wrapper function that:
- Removes the curl `-f` flag so we can log HTTP error response bodies (to diagnose errors like 403s instead of them just exiting with an ambiguous code 22).
- Adds curl retry logic (`--retry 3 --retry-delay 5`) to handle transient network issues.
- Allows reading an optional `GITHUB_TOKEN` from the environment and passing it as a Bearer token in the Authorization header to greatly increase rate limits and resolve the 403 issue.

The `.github/workflows/update-readme.yml` workflow was also updated to pass `${{ secrets.GITHUB_TOKEN }}` to the script to fix the 403s on GitHub Actions.

---
*PR created automatically by Jules for task [13794052602980210476](https://jules.google.com/task/13794052602980210476) started by @arran4*