### PR TITLE
feat: add monthly inactive repository report workflow

### DIFF
--- a/.github/workflows/monthly-report.yml
+++ b/.github/workflows/monthly-report.yml
@@ -1,0 +1,22 @@
+name: Monthly Repository Report
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Generate and Create Report Issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/monthly_repo_report.py

--- a/.github/workflows/monthly-report.yml
+++ b/.github/workflows/monthly-report.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: '0 0 1 * *'
   workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/monthly-report.yml'
+      - 'scripts/monthly_repo_report.py'
 
 permissions:
   issues: write

--- a/scripts/monthly_repo_report.py
+++ b/scripts/monthly_repo_report.py
@@ -1,0 +1,132 @@
+import urllib.request
+import urllib.error
+import json
+import datetime
+import os
+import sys
+
+USER = os.environ.get('GITHUB_REPOSITORY_OWNER', 'arran4')
+
+def fetch_repos():
+    repos = []
+    page = 1
+    while True:
+        url = f'https://api.github.com/users/{USER}/repos?per_page=100&page={page}'
+        req = urllib.request.Request(url)
+        token = os.environ.get('GITHUB_TOKEN')
+        if token:
+            req.add_header('Authorization', f'Bearer {token}')
+        req.add_header('Accept', 'application/vnd.github.v3+json')
+
+        try:
+            with urllib.request.urlopen(req) as response:
+                data = json.loads(response.read().decode('utf-8'))
+                if not data:
+                    break
+                repos.extend(data)
+                if len(data) < 100:
+                    break
+                page += 1
+        except urllib.error.URLError as e:
+            print(f"Error fetching repos: {e}")
+            sys.exit(1)
+
+    return repos
+
+def filter_and_sort_repos(repos):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    thirty_days_ago = now - datetime.timedelta(days=30)
+
+    filtered_repos = []
+    for repo in repos:
+        # Exclude private and archived repos
+        if repo.get('private') or repo.get('archived'):
+            continue
+
+        # Parse last pushed/updated date
+        pushed_at_str = repo.get('pushed_at') or repo.get('updated_at')
+        if not pushed_at_str:
+            continue
+
+        pushed_at = datetime.datetime.strptime(pushed_at_str, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=datetime.timezone.utc)
+
+        # Exclude repos with activity in the last 30 days
+        if pushed_at >= thirty_days_ago:
+            continue
+
+        filtered_repos.append({
+            'name': repo.get('name'),
+            'url': repo.get('html_url'),
+            'pushed_at': pushed_at,
+            'fork': repo.get('fork', False)
+        })
+
+    # Sort ascending by last modified date
+    filtered_repos.sort(key=lambda x: x['pushed_at'])
+    return filtered_repos
+
+def generate_markdown(repos):
+    non_forks = [r for r in repos if not r['fork']]
+    forks = [r for r in repos if r['fork']]
+
+    lines = [f"Hi @{USER}, here is your monthly repository report!"]
+    lines.append("\nThese public, non-archived repositories haven't seen activity in the last month.")
+
+    lines.append("\n## Non-Forks")
+    if non_forks:
+        for repo in non_forks:
+            lines.append(f"- [{repo['name']}]({repo['url']}) - Last activity: {repo['pushed_at'].strftime('%Y-%m-%d')}")
+    else:
+        lines.append("No non-forks to report.")
+
+    lines.append("\n## Forks")
+    if forks:
+        for repo in forks:
+            lines.append(f"- [{repo['name']}]({repo['url']}) - Last activity: {repo['pushed_at'].strftime('%Y-%m-%d')}")
+    else:
+        lines.append("No forks to report.")
+
+    return '\n'.join(lines)
+
+def create_issue(title, body):
+    token = os.environ.get('GITHUB_TOKEN')
+    repo = os.environ.get('GITHUB_REPOSITORY', f'{USER}/arran4') # fallback
+
+    if not token:
+        print("GITHUB_TOKEN not set. Skipping issue creation.")
+        print(body)
+        return
+
+    url = f'https://api.github.com/repos/{repo}/issues'
+    data = json.dumps({'title': title, 'body': body}).encode('utf-8')
+    req = urllib.request.Request(url, data=data, method='POST')
+    req.add_header('Authorization', f'Bearer {token}')
+    req.add_header('Accept', 'application/vnd.github.v3+json')
+    req.add_header('Content-Type', 'application/json')
+
+    try:
+        with urllib.request.urlopen(req) as response:
+            result = json.loads(response.read().decode('utf-8'))
+            print(f"Issue created successfully: {result.get('html_url')}")
+    except urllib.error.URLError as e:
+        print(f"Error creating issue: {e}")
+        if hasattr(e, 'read'):
+            print(e.read().decode('utf-8'))
+        sys.exit(1)
+
+def main():
+    repos = fetch_repos()
+    filtered_repos = filter_and_sort_repos(repos)
+    markdown_body = generate_markdown(filtered_repos)
+
+    title = f"Monthly Repository Report - {datetime.datetime.now(datetime.timezone.utc).strftime('%B %Y')}"
+
+    if os.environ.get('DRY_RUN'):
+        print(f"Title: {title}")
+        print("\nBody:")
+        print(markdown_body)
+    else:
+        create_issue(title, markdown_body)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/monthly_repo_report.py
+++ b/scripts/monthly_repo_report.py
@@ -19,7 +19,7 @@ def fetch_repos():
         req.add_header('Accept', 'application/vnd.github.v3+json')
 
         try:
-            with urllib.request.urlopen(req) as response:
+            with urllib.request.urlopen(req, timeout=10) as response:
                 data = json.loads(response.read().decode('utf-8'))
                 if not data:
                     break
@@ -29,6 +29,8 @@ def fetch_repos():
                 page += 1
         except urllib.error.URLError as e:
             print(f"Error fetching repos: {e}")
+            if hasattr(e, 'read'):
+                print(e.read().decode('utf-8'))
             sys.exit(1)
 
     return repos
@@ -105,7 +107,7 @@ def create_issue(title, body):
     req.add_header('Content-Type', 'application/json')
 
     try:
-        with urllib.request.urlopen(req) as response:
+        with urllib.request.urlopen(req, timeout=10) as response:
             result = json.loads(response.read().decode('utf-8'))
             print(f"Issue created successfully: {result.get('html_url')}")
     except urllib.error.URLError as e:


### PR DESCRIPTION
Added a Python script (`scripts/monthly_repo_report.py`) that lists inactive public repositories, and an associated GitHub Actions workflow (`.github/workflows/monthly-report.yml`) that runs at the start of every month to produce a report formatted as an Issue, per user request.

---
*PR created automatically by Jules for task [3834524892322047099](https://jules.google.com/task/3834524892322047099) started by @arran4*