### PR TITLE
Update `parse_diff.py` to fix formatting of description updates

### DIFF
--- a/scripts/parse_diff.py
+++ b/scripts/parse_diff.py
@@ -120,12 +120,12 @@ def main():
                     changes_list.append(f"Changed owner from `{d.owner}` to `{a.owner}`")
                 else:
                     changes_list.append(f"Renamed from `{d.name}` to `{a.name}`")
-            if d.desc != a.desc:
-                d_desc_clean = d.desc.replace('`', '') if d.desc else ''
-                a_desc_clean = a.desc.replace('`', '') if a.desc else ''
-                if not d.desc and a.desc:
+            d_desc_clean = d.desc.replace('`', '') if d.desc else ''
+            a_desc_clean = a.desc.replace('`', '') if a.desc else ''
+            if d_desc_clean != a_desc_clean:
+                if not d_desc_clean and a_desc_clean:
                     changes_list.append(f"Added description `{a_desc_clean}`")
-                elif d.desc and not a.desc:
+                elif d_desc_clean and not a_desc_clean:
                     changes_list.append(f"Removed description")
                 else:
                     bold_old, bold_new = bold_difference(d_desc_clean, a_desc_clean)

--- a/scripts/parse_diff.py
+++ b/scripts/parse_diff.py
@@ -124,12 +124,12 @@ def main():
             a_desc_clean = a.desc.replace('`', '') if a.desc else ''
             if d_desc_clean != a_desc_clean:
                 if not d_desc_clean and a_desc_clean:
-                    changes_list.append(f"Added description `{a_desc_clean}`")
+                    changes_list.append(f"Added description:\n\n> {a_desc_clean}\n\n")
                 elif d_desc_clean and not a_desc_clean:
                     changes_list.append(f"Removed description")
                 else:
                     bold_old, bold_new = bold_difference(d_desc_clean, a_desc_clean)
-                    changes_list.append(f"Updated description from {bold_old} to {bold_new}")
+                    changes_list.append(f"Updated description from:\n\n> {bold_old}\n\nTo:\n\n> {bold_new}\n\n")
             if d.homepage != a.homepage:
                 if d.homepage or a.homepage:
                     changes_list.append(f"Updated homepage from `{d.homepage}` to `{a.homepage}`")

--- a/scripts/parse_diff.py
+++ b/scripts/parse_diff.py
@@ -121,9 +121,15 @@ def main():
                 else:
                     changes_list.append(f"Renamed from `{d.name}` to `{a.name}`")
             if d.desc != a.desc:
-                if d.desc or a.desc:
-                    bold_old, bold_new = bold_difference(d.desc, a.desc)
-                    changes_list.append(f"Updated description from `{bold_old}` to `{bold_new}`")
+                d_desc_clean = d.desc.replace('`', '') if d.desc else ''
+                a_desc_clean = a.desc.replace('`', '') if a.desc else ''
+                if not d.desc and a.desc:
+                    changes_list.append(f"Added description `{a_desc_clean}`")
+                elif d.desc and not a.desc:
+                    changes_list.append(f"Removed description")
+                else:
+                    bold_old, bold_new = bold_difference(d_desc_clean, a_desc_clean)
+                    changes_list.append(f"Updated description from {bold_old} to {bold_new}")
             if d.homepage != a.homepage:
                 if d.homepage or a.homepage:
                     changes_list.append(f"Updated homepage from `{d.homepage}` to `{a.homepage}`")


### PR DESCRIPTION
Update `parse_diff.py` to fix formatting of description updates. The `bold_difference` string should not be enclosed in backticks because that breaks the markdown renderer causing it to show `**` instead of rendering bold text. Also handles empty values explicitly (Added/Removed).

---
*PR created automatically by Jules for task [10840038105549596924](https://jules.google.com/task/10840038105549596924) started by @arran4*