### PR TITLE
Improve markdown rendering for parse_diff.py

### DIFF
--- a/scripts/parse_diff.py
+++ b/scripts/parse_diff.py
@@ -158,7 +158,7 @@ def main():
                 for change in changes_list:
                     if '\n' in change:
                         formatted_change = change.strip().replace('\n', '\n    ')
-                        output.append(f"  - {formatted_change}\n")
+                        output.append(f"  - {formatted_change}")
                     else:
                         output.append(f"  - {change}")
 

--- a/scripts/parse_diff.py
+++ b/scripts/parse_diff.py
@@ -151,7 +151,16 @@ def main():
             if not changes_list:
                 changes_list.append("Row formatted or modified")
 
-            output.append(f"- **Updated** [{a.name}]({a.repo_url}): {'; '.join(changes_list)}")
+            if len(changes_list) == 1 and '\n' not in changes_list[0]:
+                output.append(f"- **Updated** [{a.name}]({a.repo_url}): {changes_list[0]}")
+            else:
+                output.append(f"- **Updated** [{a.name}]({a.repo_url}):")
+                for change in changes_list:
+                    if '\n' in change:
+                        formatted_change = change.strip().replace('\n', '\n    ')
+                        output.append(f"  - {formatted_change}\n")
+                    else:
+                        output.append(f"  - {change}")
 
         output.append("\n")
 


### PR DESCRIPTION
This PR improves the markdown rendering produced by `scripts/parse_diff.py`. Previously, it outputted multiple changes using a semicolon-separated list. If any of the changes spanned multiple lines (like description blocks with blockquotes), the inline format would break standard markdown list rendering. 

This commit updates the output to use a nested markdown list when there are multi-line changes or multiple changes to a single repository row, ensuring valid and visually clear output. Internal newlines are properly indented with four spaces to adhere to the markdown specification for list continuations.

---
*PR created automatically by Jules for task [13761894443478381426](https://jules.google.com/task/13761894443478381426) started by @arran4*