### PR TITLE
Update workflow schedules to 6am AEST

### DIFF
--- a/.github/workflows/monthly-report.yml
+++ b/.github/workflows/monthly-report.yml
@@ -1,7 +1,7 @@
 name: Monthly Repository Report
 on:
   schedule:
-    - cron: '0 0 1 * *'
+    - cron: '0 20 1 * *'
   workflow_dispatch:
   push:
     paths:

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -2,7 +2,7 @@ name: Update README repo table
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 20 * * *'
 
 permissions:
   contents: write


### PR DESCRIPTION
Updates the cron schedules in `.github/workflows/monthly-report.yml` and `.github/workflows/update-readme.yml` to run at 20:00 UTC, which corresponds to approximately 6:00 AM Australian EST.

---
*PR created automatically by Jules for task [11997949309620142420](https://jules.google.com/task/11997949309620142420) started by @arran4*