### PR TITLE
ci: Restrict monthly report workflow to main and master branches

### DIFF
--- a/.github/workflows/monthly-report.yml
+++ b/.github/workflows/monthly-report.yml
@@ -4,6 +4,9 @@ on:
     - cron: '0 20 1 * *'
   workflow_dispatch:
   push:
+    branches:
+      - master
+      - main
     paths:
       - '.github/workflows/monthly-report.yml'
       - 'scripts/monthly_repo_report.py'
@@ -13,6 +16,7 @@ permissions:
 
 jobs:
   report:
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the issue where the monthly report workflow could be triggered on non-main branches. Added branch filters to the push event and an if condition in the report job to only execute on master and main branches.

---
*PR created automatically by Jules for task [1117616518608397771](https://jules.google.com/task/1117616518608397771) started by @arran4*