### PR TITLE
Add license change summary to pull request output

### DIFF
--- a/scripts/parse_diff.py
+++ b/scripts/parse_diff.py
@@ -180,11 +180,13 @@ def main():
                     if not d.extra_info:
                         changes_list.append(f"Added {info_name}: `{a.extra_info}`")
                         if info_name == "license":
-                            license_changes_summary.append(f"- [{a.name}]({a.repo_url}): Added license `{a.extra_info}`")
+                            repo_link = f"[{a.name}]({a.repo_url})" if a.repo_url else a.name
+                            license_changes_summary.append(f"- {repo_link}: Added license `{a.extra_info}`")
                     elif not a.extra_info:
                         changes_list.append(f"Removed {info_name}: `{d.extra_info}`")
                         if info_name == "license":
-                            license_changes_summary.append(f"- [{a.name}]({a.repo_url}): Removed license `{d.extra_info}`")
+                            repo_link = f"[{a.name}]({a.repo_url})" if a.repo_url else a.name
+                            license_changes_summary.append(f"- {repo_link}: Removed license `{d.extra_info}`")
                     else:
                         if info_name == "latest release":
                             d_date = parse_date(d.extra_info)
@@ -205,7 +207,8 @@ def main():
                         else:
                             changes_list.append(f"Changed {info_name} from `{d.extra_info}` to `{a.extra_info}`")
                             if info_name == "license":
-                                license_changes_summary.append(f"- [{a.name}]({a.repo_url}): Changed license from `{d.extra_info}` to `{a.extra_info}`")
+                                repo_link = f"[{a.name}]({a.repo_url})" if a.repo_url else a.name
+                                license_changes_summary.append(f"- {repo_link}: Changed license from `{d.extra_info}` to `{a.extra_info}`")
 
                 d_tags = d.get_tags_set()
                 a_tags = a.get_tags_set()

--- a/scripts/parse_diff.py
+++ b/scripts/parse_diff.py
@@ -78,6 +78,7 @@ class Row:
 
 def main():
     files_changed = {}
+    license_changes_summary = []
     current_file = None
 
     for line in sys.stdin:
@@ -178,8 +179,12 @@ def main():
                 if d.extra_info != a.extra_info:
                     if not d.extra_info:
                         changes_list.append(f"Added {info_name}: `{a.extra_info}`")
+                        if info_name == "license":
+                            license_changes_summary.append(f"- [{a.name}]({a.repo_url}): Added license `{a.extra_info}`")
                     elif not a.extra_info:
                         changes_list.append(f"Removed {info_name}: `{d.extra_info}`")
+                        if info_name == "license":
+                            license_changes_summary.append(f"- [{a.name}]({a.repo_url}): Removed license `{d.extra_info}`")
                     else:
                         if info_name == "latest release":
                             d_date = parse_date(d.extra_info)
@@ -199,6 +204,8 @@ def main():
                             })
                         else:
                             changes_list.append(f"Changed {info_name} from `{d.extra_info}` to `{a.extra_info}`")
+                            if info_name == "license":
+                                license_changes_summary.append(f"- [{a.name}]({a.repo_url}): Changed license from `{d.extra_info}` to `{a.extra_info}`")
 
                 d_tags = d.get_tags_set()
                 a_tags = a.get_tags_set()
@@ -315,6 +322,11 @@ def main():
     if summary_output:
         print("**Repository Changes Summary:**\n")
         print("\n".join(summary_output))
+
+        if license_changes_summary:
+            print("\n**License Changes:**\n")
+            print("\n".join(license_changes_summary))
+
         print("\n<details><summary>Detailed Repository Changes</summary>\n")
 
         details_str = "\n".join(output)


### PR DESCRIPTION
Adds a license change summary to the PR body using `scripts/parse_diff.py` so we can track license updates easily.

---
*PR created automatically by Jules for task [2859657136174770238](https://jules.google.com/task/2859657136174770238) started by @arran4*