### PR TITLE
Fix false-positive repo table updates in CI

### DIFF
--- a/scripts/fetch_starred_releases.py
+++ b/scripts/fetch_starred_releases.py
@@ -55,6 +55,7 @@ def fetch_releases(repos, token):
                             results[repo_data['nameWithOwner'].lower()] = repo_data['latestRelease']
         except Exception as e:
             print(f"Error fetching GraphQL for releases: {e}", file=sys.stderr)
+            sys.exit(1)
 
     return results
 

--- a/scripts/parse_diff.py
+++ b/scripts/parse_diff.py
@@ -74,7 +74,7 @@ class Row:
 
     def get_tags_set(self):
         if not self.tags: return set()
-        tags_str = self.tags.replace(' + ', ', ')
+        tags_str = re.sub(r'\s*\+\s*', ', ', self.tags)
         return set([t.strip() for t in tags_str.split(',') if t.strip()])
 
 def main():

--- a/scripts/parse_diff.py
+++ b/scripts/parse_diff.py
@@ -74,7 +74,8 @@ class Row:
 
     def get_tags_set(self):
         if not self.tags: return set()
-        return set([t.strip() for t in self.tags.split(',') if t.strip()])
+        tags_str = self.tags.replace(' + ', ', ')
+        return set([t.strip() for t in tags_str.split(',') if t.strip()])
 
 def main():
     files_changed = {}

--- a/scripts/update_repo_table.sh
+++ b/scripts/update_repo_table.sh
@@ -310,7 +310,7 @@ while true; do
 done
 
 STARRED_RELEASES="$TMP_DIR/starred_releases.json"
-python3 scripts/fetch_starred_releases.py "$ALL_STARRED" "$STARRED_RELEASES"
+python3 scripts/fetch_starred_releases.py "$ALL_STARRED" "$STARRED_RELEASES" || exit 1
 
 ALL_STARRED_WITH_RELEASES="$TMP_DIR/all_starred_with_releases.json"
 jq -s '.[0] as $releases | .[1] | map(. + {latest_release_tag: $releases[.full_name | ascii_downcase]?.tagName, latest_release_date: $releases[.full_name | ascii_downcase]?.publishedAt})' "$STARRED_RELEASES" "$ALL_STARRED" > "$ALL_STARRED_WITH_RELEASES"

--- a/scripts/update_repo_table.sh
+++ b/scripts/update_repo_table.sh
@@ -310,6 +310,10 @@ while true; do
 done
 
 STARRED_RELEASES="$TMP_DIR/starred_releases.json"
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "Error: GITHUB_TOKEN is not set. Aborting to prevent wiping out release history." >&2
+  exit 1
+fi
 python3 scripts/fetch_starred_releases.py "$ALL_STARRED" "$STARRED_RELEASES" || exit 1
 
 ALL_STARRED_WITH_RELEASES="$TMP_DIR/all_starred_with_releases.json"


### PR DESCRIPTION
Fixes two issues with the `update-repo-table` CI job that resulted in confusing updates in the PR summary:
1. False positive tag updates appearing because of differences between ` + ` and `, ` in tag lists.
2. False "Removed latest release" messages for starred repositories caused by `fetch_starred_releases.py` silently failing on API requests, returning an empty JSON object, and wiping out the release history. Now it exits with an error code and the CI job will fail and abort rather than generating a corrupted markdown table.

---
*PR created automatically by Jules for task [5831764999123275023](https://jules.google.com/task/5831764999123275023) started by @arran4*