### PR TITLE
Add GitHub API backoff logic

### DIFF
--- a/scripts/fetch_starred_releases.py
+++ b/scripts/fetch_starred_releases.py
@@ -3,6 +3,7 @@ import sys
 import json
 import urllib.request
 import urllib.error
+import time
 
 def fetch_releases(repos, token):
     if not token:
@@ -46,15 +47,56 @@ def fetch_releases(repos, token):
             "Content-Type": "application/json"
         })
 
-        try:
-            with urllib.request.urlopen(req, timeout=10) as response:
-                data = json.loads(response.read().decode())
-                if 'data' in data:
-                    for alias, repo_data in data['data'].items():
-                        if repo_data and repo_data.get('latestRelease'):
-                            results[repo_data['nameWithOwner'].lower()] = repo_data['latestRelease']
-        except Exception as e:
-            print(f"Error fetching GraphQL for releases: {e}", file=sys.stderr)
+        max_retries = 5
+        for attempt in range(max_retries):
+            try:
+                with urllib.request.urlopen(req, timeout=10) as response:
+                    data = json.loads(response.read().decode())
+                    if 'data' in data:
+                        for alias, repo_data in data['data'].items():
+                            if repo_data and repo_data.get('latestRelease'):
+                                results[repo_data['nameWithOwner'].lower()] = repo_data['latestRelease']
+                    break # Success, exit retry loop
+            except urllib.error.HTTPError as e:
+                status_code = e.code
+                if status_code in [403, 429] or 500 <= status_code < 600:
+                    retry_after = e.headers.get('Retry-After')
+                    reset_time = e.headers.get('x-ratelimit-reset')
+
+                    sleep_time = 2 ** attempt # Default exponential backoff
+
+                    if attempt == max_retries - 1:
+                        print(f"HTTP Error {status_code} fetching GraphQL for releases (Max retries reached)", file=sys.stderr)
+                        sys.exit(1)
+
+                    if retry_after:
+                        try:
+                            sleep_time = int(retry_after)
+                        except ValueError:
+                            pass
+                    elif reset_time:
+                        try:
+                            reset_timestamp = int(reset_time)
+                            current_timestamp = int(time.time())
+                            if reset_timestamp > current_timestamp:
+                                sleep_time = reset_timestamp - current_timestamp + 1
+                        except ValueError:
+                            pass
+
+                    print(f"HTTP Error {status_code} fetching GraphQL for releases. Retrying in {sleep_time} seconds (attempt {attempt + 1}/{max_retries})...", file=sys.stderr)
+                    time.sleep(sleep_time)
+                else:
+                    print(f"Error fetching GraphQL for releases: {e}", file=sys.stderr)
+                    sys.exit(1)
+            except Exception as e:
+                print(f"Error fetching GraphQL for releases: {e}", file=sys.stderr)
+                if attempt == max_retries - 1:
+                    sys.exit(1)
+                sleep_time = 2 ** attempt
+                print(f"Retrying in {sleep_time} seconds (attempt {attempt + 1}/{max_retries})...", file=sys.stderr)
+                time.sleep(sleep_time)
+        else:
+            print("Max retries exceeded for fetching releases.", file=sys.stderr)
             sys.exit(1)
 
     return results

--- a/scripts/monthly_repo_report.py
+++ b/scripts/monthly_repo_report.py
@@ -4,8 +4,58 @@ import json
 import datetime
 import os
 import sys
+import time
 
 USER = os.environ.get('GITHUB_REPOSITORY_OWNER', 'arran4')
+
+def fetch_with_backoff(req, max_retries=5):
+    for attempt in range(max_retries):
+        try:
+            with urllib.request.urlopen(req, timeout=10) as response:
+                return response.read().decode('utf-8')
+        except urllib.error.HTTPError as e:
+            status_code = e.code
+            if status_code in [403, 429] or 500 <= status_code < 600:
+                retry_after = e.headers.get('Retry-After')
+                reset_time = e.headers.get('x-ratelimit-reset')
+
+                sleep_time = 2 ** attempt
+
+                if attempt == max_retries - 1:
+                    print(f"HTTP Error {status_code} (Max retries reached)", file=sys.stderr)
+                    sys.exit(1)
+
+                if retry_after:
+                    try:
+                        sleep_time = int(retry_after)
+                    except ValueError:
+                        pass
+                elif reset_time:
+                    try:
+                        reset_timestamp = int(reset_time)
+                        current_timestamp = int(time.time())
+                        if reset_timestamp > current_timestamp:
+                            sleep_time = reset_timestamp - current_timestamp + 1
+                    except ValueError:
+                        pass
+
+                print(f"HTTP Error {status_code}. Retrying in {sleep_time} seconds (attempt {attempt + 1}/{max_retries})...", file=sys.stderr)
+                time.sleep(sleep_time)
+            else:
+                print(f"HTTP Error: {e}", file=sys.stderr)
+                if hasattr(e, 'read'):
+                    print(e.read().decode('utf-8'), file=sys.stderr)
+                sys.exit(1)
+        except Exception as e:
+            print(f"Error fetching data: {e}", file=sys.stderr)
+            if attempt == max_retries - 1:
+                sys.exit(1)
+            sleep_time = 2 ** attempt
+            print(f"Retrying in {sleep_time} seconds (attempt {attempt + 1}/{max_retries})...", file=sys.stderr)
+            time.sleep(sleep_time)
+
+    print("Max retries exceeded.", file=sys.stderr)
+    sys.exit(1)
 
 def fetch_repos():
     repos = []
@@ -18,20 +68,14 @@ def fetch_repos():
             req.add_header('Authorization', f'Bearer {token}')
         req.add_header('Accept', 'application/vnd.github.v3+json')
 
-        try:
-            with urllib.request.urlopen(req, timeout=10) as response:
-                data = json.loads(response.read().decode('utf-8'))
-                if not data:
-                    break
-                repos.extend(data)
-                if len(data) < 100:
-                    break
-                page += 1
-        except urllib.error.URLError as e:
-            print(f"Error fetching repos: {e}")
-            if hasattr(e, 'read'):
-                print(e.read().decode('utf-8'))
-            sys.exit(1)
+        response_data = fetch_with_backoff(req)
+        data = json.loads(response_data)
+        if not data:
+            break
+        repos.extend(data)
+        if len(data) < 100:
+            break
+        page += 1
 
     return repos
 
@@ -133,13 +177,11 @@ def create_issue(title, body):
     req.add_header('Content-Type', 'application/json')
 
     try:
-        with urllib.request.urlopen(req, timeout=10) as response:
-            result = json.loads(response.read().decode('utf-8'))
-            print(f"Issue created successfully: {result.get('html_url')}")
-    except urllib.error.URLError as e:
+        response_data = fetch_with_backoff(req)
+        result = json.loads(response_data)
+        print(f"Issue created successfully: {result.get('html_url')}")
+    except Exception as e:
         print(f"Error creating issue: {e}")
-        if hasattr(e, 'read'):
-            print(e.read().decode('utf-8'))
         sys.exit(1)
 
 def main():

--- a/scripts/monthly_repo_report.py
+++ b/scripts/monthly_repo_report.py
@@ -9,13 +9,17 @@ import time
 USER = os.environ.get('GITHUB_REPOSITORY_OWNER', 'arran4')
 
 def fetch_with_backoff(req, max_retries=5):
+    method = req.method
+    if method is None:
+        method = 'POST' if req.data is not None else 'GET'
+    is_idempotent = method in ('GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS')
     for attempt in range(max_retries):
         try:
             with urllib.request.urlopen(req, timeout=10) as response:
                 return response.read().decode('utf-8')
         except urllib.error.HTTPError as e:
             status_code = e.code
-            if status_code in [403, 429] or 500 <= status_code < 600:
+            if status_code in [403, 429] or (is_idempotent and 500 <= status_code < 600):
                 retry_after = e.headers.get('Retry-After')
                 reset_time = e.headers.get('x-ratelimit-reset')
 

--- a/scripts/update_repo_table.sh
+++ b/scripts/update_repo_table.sh
@@ -15,8 +15,6 @@ fetch_github_api() {
 
   local curl_opts=(
     -sSL
-    --retry 3
-    --retry-delay 5
     -H "Accept: $accept_header"
     -w "%{http_code}"
   )
@@ -26,22 +24,63 @@ fetch_github_api() {
   fi
 
   local response_file="$TMP_DIR/curl_response"
+  local headers_file="$TMP_DIR/curl_headers"
   local http_code
+  local max_retries=5
+  local attempt=0
 
-  if ! http_code=$(curl "${curl_opts[@]}" -o "$response_file" "$url"); then
-    local exit_code=$?
-    echo "Error fetching $url (curl exit code $exit_code)" >&2
-    return $exit_code
-  fi
+  while [ $attempt -lt $max_retries ]; do
+    if ! http_code=$(curl "${curl_opts[@]}" -D "$headers_file" -o "$response_file" "$url"); then
+      local exit_code=$?
+      echo "Error fetching $url (curl exit code $exit_code)" >&2
+      if [ $attempt -eq $((max_retries-1)) ]; then
+        return $exit_code
+      fi
+      local sleep_time=$((2 ** attempt))
+      echo "Retrying in $sleep_time seconds (attempt $((attempt+1))/$max_retries)..." >&2
+      sleep $sleep_time
+      attempt=$((attempt+1))
+      continue
+    fi
 
-  if [ "$http_code" -ne 200 ]; then
+    if [ "$http_code" -eq 200 ]; then
+      mv "$response_file" "$output_file"
+      return 0
+    fi
+
+    if [ "$http_code" -eq 403 ] || [ "$http_code" -eq 429 ] || [ "$http_code" -ge 500 ]; then
+      if [ $attempt -eq $((max_retries-1)) ]; then
+        echo "Error fetching $url: HTTP status $http_code (Max retries reached)" >&2
+        return 22
+      fi
+
+      local sleep_time=$((2 ** attempt))
+      local retry_after=$(grep -i '^Retry-After:' "$headers_file" | awk '{print $2}' | tr -d '\r' || true)
+      local reset_time=$(grep -i '^x-ratelimit-reset:' "$headers_file" | awk '{print $2}' | tr -d '\r' || true)
+
+      if [ -n "$retry_after" ] && [ "$retry_after" -eq "$retry_after" ] 2>/dev/null; then
+        sleep_time=$retry_after
+      elif [ -n "$reset_time" ] && [ "$reset_time" -eq "$reset_time" ] 2>/dev/null; then
+        local current_time=$(date +%s)
+        if [ "$reset_time" -gt "$current_time" ]; then
+          sleep_time=$((reset_time - current_time + 1))
+        fi
+      fi
+
+      echo "HTTP Error $http_code fetching $url. Retrying in $sleep_time seconds (attempt $((attempt+1))/$max_retries)..." >&2
+      sleep $sleep_time
+      attempt=$((attempt+1))
+      continue
+    fi
+
     echo "Error fetching $url: HTTP status $http_code" >&2
     echo "Response body:" >&2
     cat "$response_file" >&2
-    return 22 # Return 22 to match curl -f behavior
-  fi
+    return 22
+  done
 
-  mv "$response_file" "$output_file"
+  echo "Max retries exceeded for fetching $url" >&2
+  return 22
 }
 
 PAGE=1

--- a/scripts/update_repo_table.sh
+++ b/scripts/update_repo_table.sh
@@ -31,7 +31,7 @@ fetch_github_api() {
 
   while [ $attempt -lt $max_retries ]; do
     if ! http_code=$(curl "${curl_opts[@]}" -D "$headers_file" -o "$response_file" "$url"); then
-      local exit_code=$?
+      local exit_code=${PIPESTATUS[0]}
       echo "Error fetching $url (curl exit code $exit_code)" >&2
       if [ $attempt -eq $((max_retries-1)) ]; then
         return $exit_code
@@ -55,8 +55,8 @@ fetch_github_api() {
       fi
 
       local sleep_time=$((2 ** attempt))
-      local retry_after=$(grep -i '^Retry-After:' "$headers_file" | awk '{print $2}' | tr -d '\r' || true)
-      local reset_time=$(grep -i '^x-ratelimit-reset:' "$headers_file" | awk '{print $2}' | tr -d '\r' || true)
+      local retry_after=$(grep -i '^Retry-After:' "$headers_file" | tail -n 1 | awk '{print $2}' | tr -d '\r' || true)
+      local reset_time=$(grep -i '^x-ratelimit-reset:' "$headers_file" | tail -n 1 | awk '{print $2}' | tr -d '\r' || true)
 
       if [ -n "$retry_after" ] && [ "$retry_after" -eq "$retry_after" ] 2>/dev/null; then
         sleep_time=$retry_after


### PR DESCRIPTION
Add proper backoff/retry logic adhering to HTTP response headers (`Retry-After`, `x-ratelimit-reset`) to handle API rate limiting issues in `update_repo_table.sh`, `monthly_repo_report.py`, and `fetch_starred_releases.py`.

---
*PR created automatically by Jules for task [15156221261416867075](https://jules.google.com/task/15156221261416867075) started by @arran4*