### PR TITLE
Fix AttributeError in monthly_repo_report.py

### DIFF
--- a/scripts/monthly_repo_report.py
+++ b/scripts/monthly_repo_report.py
@@ -9,9 +9,7 @@ import time
 USER = os.environ.get('GITHUB_REPOSITORY_OWNER', 'arran4')
 
 def fetch_with_backoff(req, max_retries=5):
-    method = req.method
-    if method is None:
-        method = 'POST' if req.data is not None else 'GET'
+    method = req.get_method()
     is_idempotent = method in ('GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS')
     for attempt in range(max_retries):
         try:

--- a/scripts/monthly_repo_report.py
+++ b/scripts/monthly_repo_report.py
@@ -9,7 +9,7 @@ import time
 USER = os.environ.get('GITHUB_REPOSITORY_OWNER', 'arran4')
 
 def fetch_with_backoff(req, max_retries=5):
-    method = req.get_method()
+    method = req.get_method().upper()
     is_idempotent = method in ('GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS')
     for attempt in range(max_retries):
         try:


### PR DESCRIPTION
The `urllib.request.Request` object does not have a `method` attribute initialized automatically without it. `req.get_method()` safely retrieves the method, and handles fallback.

---
*PR created automatically by Jules for task [7677611906316433547](https://jules.google.com/task/7677611906316433547) started by @arran4*