### PR TITLE
Fix jq install failure in update-readme.yml

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y jq
       - name: Update table
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change removes the `sudo apt-get update && sudo apt-get install -y jq` step from the `.github/workflows/update-readme.yml` file. This resolves intermittent failures caused by issues with Microsoft package repositories. `jq` is already pre-installed on GitHub-hosted `ubuntu-latest` runners, making this step unnecessary.

---
*PR created automatically by Jules for task [9866532940724862601](https://jules.google.com/task/9866532940724862601) started by @arran4*