### PR TITLE
Remove details wrapper from detailed diffs

### DIFF
--- a/scripts/parse_diff.py
+++ b/scripts/parse_diff.py
@@ -412,7 +412,7 @@ def main():
             print("\n**Other Info Changes:**\n")
             print("\n".join(extra_info_changes_summary))
 
-        print("\n<details><summary>Detailed Repository Changes</summary>\n")
+        print("\n### Detailed Repository Changes\n")
 
         details_str = "\n".join(output)
         if len(details_str) > 60000:
@@ -423,8 +423,6 @@ def main():
             print("\n... (Detailed changes truncated due to GitHub limits) ...")
         else:
             print(details_str)
-
-        print("\n</details>\n")
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR removes the `<details>` wrapper from the "Detailed Repository Changes" section in the output of `scripts/parse_diff.py`.

The changes ensure that detailed repository changes (like added, modified, or removed repositories within each file) are openly visible in the pull request summaries rather than being hidden in a foldable block.

---
*PR created automatically by Jules for task [12187192872735761759](https://jules.google.com/task/12187192872735761759) started by @arran4*