### PR TITLE
feat: Add programming language to PR details section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 pr-body.md
 __pycache__/
 *.py[cod]
+repo_languages.json

--- a/scripts/parse_diff.py
+++ b/scripts/parse_diff.py
@@ -3,6 +3,8 @@ import re
 import difflib
 from collections import defaultdict
 from datetime import datetime
+import json
+import os
 
 def escape_md(text):
     if not text: return ""
@@ -172,7 +174,7 @@ class RepoChange:
         return set([t.strip() for t in tags_str.split(',') if t.strip()])
 
 
-def format_card(repo):
+def format_card(repo, languages):
     output = []
 
     # Icons
@@ -214,6 +216,11 @@ def format_card(repo):
 
     if reasons:
         output.append(f"**Reason:** {', '.join(reasons)}")
+
+    # Language
+    repo_key = repo.key
+    if repo_key in languages:
+        output.append(f"**Language:** {languages[repo_key]}")
 
     def format_label(label, has_changed):
         return f"**{label}:**" if has_changed else f"{label}:"
@@ -346,6 +353,14 @@ def format_card(repo):
 def main(input_stream=None):
     if input_stream is None:
         input_stream = sys.stdin
+
+    languages = {}
+    if os.path.exists("repo_languages.json"):
+        with open("repo_languages.json", "r") as f:
+            try:
+                languages = json.load(f)
+            except json.JSONDecodeError:
+                pass
 
     files_changed = {}
     current_file = None
@@ -547,7 +562,7 @@ def main(input_stream=None):
     # Sort repos alphabetically
     sorted_repos = sorted(repo_changes.values(), key=lambda r: r.key.lower())
     for repo in sorted_repos:
-        print(format_card(repo))
+        print(format_card(repo, languages))
         print()
 
 if __name__ == '__main__':

--- a/scripts/update_repo_table.sh
+++ b/scripts/update_repo_table.sh
@@ -417,3 +417,9 @@ $0==start{print;for(i=1;i<=length(lines);i++)print lines[i];skip=1;next}
 $0==end{skip=0;print;next}
 !skip{print}
 ' "$STARRED_TABLE" "$STARRED_MD" > "$STARRED_MD.tmp" && mv "$STARRED_MD.tmp" "$STARRED_MD"
+
+LANGUAGES_FILE="repo_languages.json"
+jq -s '
+  def get_name: .full_name // (if .owner.login? then .owner.login + "/" + .name else .name end);
+  [.[][] | select(get_name != null and .language != null)] | map({key: get_name, value: .language}) | from_entries
+' "$ALL" "$ALL_STARRED" > "$LANGUAGES_FILE"


### PR DESCRIPTION
Extracts the programming language for each repository directly from the GitHub API responses and injects it into the detailed repository output of the generated PR summary.

---
*PR created automatically by Jules for task [12693349678114771603](https://jules.google.com/task/12693349678114771603) started by @arran4*