### PR TITLE
feat: add PR and commits ahead stats to monthly report

### DIFF
--- a/scripts/monthly_repo_report.py
+++ b/scripts/monthly_repo_report.py
@@ -8,7 +8,7 @@ import time
 
 USER = os.environ.get('GITHUB_REPOSITORY_OWNER', 'arran4')
 
-def fetch_with_backoff(req, max_retries=5):
+def fetch_with_backoff(req, max_retries=5, ignore_errors=None):
     method = req.get_method().upper()
     is_idempotent = method in ('GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS')
     for attempt in range(max_retries):
@@ -22,6 +22,9 @@ def fetch_with_backoff(req, max_retries=5):
                 reset_time = e.headers.get('x-ratelimit-reset')
 
                 sleep_time = 2 ** attempt
+
+                if ignore_errors and status_code in ignore_errors:
+                    return None
 
                 if attempt == max_retries - 1:
                     print(f"HTTP Error {status_code} (Max retries reached)", file=sys.stderr)
@@ -44,6 +47,8 @@ def fetch_with_backoff(req, max_retries=5):
                 print(f"HTTP Error {status_code}. Retrying in {sleep_time} seconds (attempt {attempt + 1}/{max_retries})...", file=sys.stderr)
                 time.sleep(sleep_time)
             else:
+                if ignore_errors and status_code in ignore_errors:
+                    return None
                 print(f"HTTP Error: {e}", file=sys.stderr)
                 if hasattr(e, 'read'):
                     print(e.read().decode('utf-8'), file=sys.stderr)
@@ -80,6 +85,101 @@ def fetch_repos():
         page += 1
 
     return repos
+
+
+
+def fetch_prs_for_month():
+    now = datetime.datetime.now(datetime.timezone.utc)
+    first_day_of_this_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    last_month = first_day_of_this_month - datetime.timedelta(days=1)
+    first_day_of_last_month = last_month.replace(day=1)
+
+    date_str = first_day_of_last_month.strftime('%Y-%m-%dT%H:%M:%SZ')
+    end_date_str = (first_day_of_this_month - datetime.timedelta(seconds=1)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    print(f"Fetching PRs created between {date_str} and {end_date_str}...", file=sys.stderr)
+
+    prs_by_repo = {}
+    page = 1
+    while True:
+        url = f'https://api.github.com/search/issues?q=user:{USER}+type:pr+created:{date_str}..{end_date_str}&per_page=100&page={page}'
+        req = urllib.request.Request(url)
+        token = os.environ.get('GITHUB_TOKEN')
+        if token:
+            req.add_header('Authorization', f'Bearer {token}')
+        req.add_header('Accept', 'application/vnd.github.v3+json')
+
+        response_data = fetch_with_backoff(req)
+        if not response_data:
+            break
+
+        data = json.loads(response_data)
+        items = data.get('items', [])
+        if not items:
+            break
+
+        for item in items:
+            repo_url = item.get('repository_url', '')
+            repo_name = repo_url.split('/')[-1]
+            if repo_name not in prs_by_repo:
+                prs_by_repo[repo_name] = {'count': 0, 'url': f'https://github.com/{USER}/{repo_name}'}
+            prs_by_repo[repo_name]['count'] += 1
+
+        if len(items) < 100:
+            break
+        page += 1
+
+    sorted_prs = [(k, v['url'], v['count']) for k, v in prs_by_repo.items()]
+    sorted_prs.sort(key=lambda x: x[2], reverse=True)
+    return sorted_prs
+
+
+
+def fetch_commits_ahead(repos):
+    print("Fetching commits ahead of latest release for repositories...", file=sys.stderr)
+    ahead_list = []
+
+    for repo in repos:
+        repo_name = repo.get('name')
+        repo_url = repo.get('html_url', f'https://github.com/{USER}/{repo_name}')
+        full_name = f"{USER}/{repo_name}"
+
+        # Get latest release
+        rel_url = f'https://api.github.com/repos/{full_name}/releases/latest'
+        req = urllib.request.Request(rel_url)
+        token = os.environ.get('GITHUB_TOKEN')
+        if token:
+            req.add_header('Authorization', f'Bearer {token}')
+        req.add_header('Accept', 'application/vnd.github.v3+json')
+
+        rel_data = fetch_with_backoff(req, ignore_errors=[404])
+        if not rel_data:
+            continue
+
+        rel_json = json.loads(rel_data)
+        tag_name = rel_json.get('tag_name')
+        if not tag_name:
+            continue
+
+        # Get compare ahead
+        comp_url = f'https://api.github.com/repos/{full_name}/compare/{tag_name}...HEAD'
+        req = urllib.request.Request(comp_url)
+        if token:
+            req.add_header('Authorization', f'Bearer {token}')
+        req.add_header('Accept', 'application/vnd.github.v3+json')
+
+        comp_data = fetch_with_backoff(req, ignore_errors=[404])
+        if not comp_data:
+            continue
+
+        comp_json = json.loads(comp_data)
+        ahead_by = comp_json.get('ahead_by')
+
+        if ahead_by is not None and ahead_by > 0:
+            ahead_list.append((repo_name, repo_url, ahead_by, tag_name))
+
+    ahead_list.sort(key=lambda x: x[2], reverse=True)
+    return ahead_list
 
 def filter_and_sort_repos(repos):
     now = datetime.datetime.now(datetime.timezone.utc)
@@ -133,7 +233,7 @@ def group_repos_by_milestone(repos_list):
 
     return groups
 
-def generate_markdown(repos):
+def generate_markdown(repos, prs, commits_ahead):
     non_forks = [r for r in repos if not r['fork']]
     forks = [r for r in repos if r['fork']]
 
@@ -159,6 +259,16 @@ def generate_markdown(repos):
 
     lines.append("\n## Forks")
     add_repo_groups(forks, "forks")
+
+    if prs:
+        lines.append("\n## Pull Requests This Month")
+        for repo_name, url, count in prs:
+            lines.append(f"- [{repo_name}]({url}): {count} PR(s)")
+
+    if commits_ahead:
+        lines.append("\n## Commits Ahead of Latest Release")
+        for repo_name, url, ahead_by, tag_name in commits_ahead:
+            lines.append(f"- [{repo_name}]({url}): {ahead_by} commits ahead of {tag_name}")
 
     return '\n'.join(lines)
 
@@ -189,7 +299,11 @@ def create_issue(title, body):
 def main():
     repos = fetch_repos()
     filtered_repos = filter_and_sort_repos(repos)
-    markdown_body = generate_markdown(filtered_repos)
+
+    prs = fetch_prs_for_month()
+    commits_ahead = fetch_commits_ahead(repos)
+
+    markdown_body = generate_markdown(filtered_repos, prs, commits_ahead)
 
     title = f"Monthly Repository Report - {datetime.datetime.now(datetime.timezone.utc).strftime('%B %Y')}"
 


### PR DESCRIPTION
Adds two new sorted sections to the monthly repository report: one displaying the number of Pull Requests created for each repository in the past month, and another showing how many commits ahead of the latest release each repository is. Uses standard library HTTP clients with built-in retry backoff to robustly gather the data from GitHub APIs.

---
*PR created automatically by Jules for task [4758982774841811929](https://jules.google.com/task/4758982774841811929) started by @arran4*