### PR TITLE
Update update-readme.yml to run at 5am AEST

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -2,7 +2,7 @@ name: Update README repo table
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 20 * * *'
+    - cron: '0 19 * * *'
 
 permissions:
   contents: write


### PR DESCRIPTION
Changed the cron schedule in `.github/workflows/update-readme.yml` to run at 5am AEST (19:00 UTC) as requested.

---
*PR created automatically by Jules for task [11235954024184810031](https://jules.google.com/task/11235954024184810031) started by @arran4*